### PR TITLE
No such method matchIP() on SPFLib\Checker, use $state not $this

### DIFF
--- a/src/Checker.php
+++ b/src/Checker.php
@@ -367,7 +367,7 @@ class Checker
         foreach ($mxRecords as $mxRecord) {
             $mxRecordIP = Factory::addressFromString($mxRecord);
             if ($mxRecordIP !== null) {
-                if ($this->matchIP($mxRecordIP, $mechanism->getIp4CidrLength(), $mechanism->getIp6CidrLength())) {
+                if ($state->matchIP($mxRecordIP, $mechanism->getIp4CidrLength(), $mechanism->getIp6CidrLength())) {
                     return true;
                 }
             } else {


### PR DESCRIPTION
Fix an issue with checking the validity of the mx mechanism.