### PR TITLE
Include more information about DNS lookups in `OnlineSemanticValidator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The result of these methods are arrays of `SPFLib\Semantic\OnlineIssue` instance
 
 ### Dealing with too many DNS lookups
 
-When the validation returns an issue of type `SPFLib\Semantic\OnlineIssueTooManyDNSLookups`, you can get more details from the instance:
+When the validation returns an issue of type `SPFLib\Semantic\OnlineIssue\TooManyDNSLookups`, you can get more details from the instance:
 
 ```php
 // Get the total amount of DNS lookups referenced in the SPF record

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Please note that every item in the array returned by the `validate` method is an
 
 ### Checking problems with an SPF record in real world
 
-The `SemanticValidator` only look for issues in an SPF record, without inspecting include (or redirected-to) records.
+The `SemanticValidator` only looks for issues in an SPF record, without inspecting include (or redirected-to) records.
 
 In order to check an SPF record and all the referenced records you can use the `OnlineSemanticValidator`:
 
@@ -208,6 +208,29 @@ $issues = $validator->validateRecord($record);
 ```
 
 The result of these methods are arrays of `SPFLib\Semantic\OnlineIssue` instances, which are very similar to the `SPFLib\Semantic\Issue` instances returned by the offline `SemanticValidator`.
+
+### Dealing with too many DNS lookups
+
+When the validation returns an issue of type `SPFLib\Semantic\OnlineIssueTooManyDNSLookups`, you can get more details from the instance:
+
+```php
+// Get the total amount of DNS lookups referenced in the SPF record
+$totalDnsLookups = $issue->getTotalLookupCount();
+// Get a recursive list of referenced DNS lookups
+$lookups = $issue->getDnsLookups();
+```
+
+You can also explicitly retrieve a list of DNS lookups for a SPF record by calling the relevant methods of `OnlineSemanticValidator`:
+
+```php
+$validator = new \SPFLib\OnlineSemanticValidator();
+// Get the DNS lookups for an online domain
+$lookups = $validator->getLookupsForDomain('example.org');
+// Get the DNS lookups for a raw SPF record
+$lookups = $validator->getLookupsForRawRecord('v=spf1 include:_sfp.example.org -all');
+// Get the DNS lookups for an SPFLib\Record instance ($record in this case)
+$lookups = $validator->getLookupsForRecord($record);
+```
 
 ## Do you want to really say thank you?
 

--- a/src/OnlineDnsLookup.php
+++ b/src/OnlineDnsLookup.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPFLib;
+
+/**
+ * Information about a DNS lookup referenced in an SPF record.
+ */
+class OnlineDnsLookup
+{
+    private string $name;
+    private ?string $record;
+    private array $references = [];
+
+    public function __construct(string $name, ?string $record = null)
+    {
+        $this->name = $name;
+        $this->record = $record;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getRecord(): string
+    {
+        return $this->record;
+    }
+
+    /**
+     * Add a recursive reference that is included within this lookup's record.
+     *
+     * @param OnlineDnsLookup $reference
+     */
+    public function addReference(OnlineDnsLookup $reference): void
+    {
+        $this->references[] = $reference;
+    }
+
+    /**
+     * Get all recursive references that are included in this lookup's record.
+     *
+     * @return array<self>
+     */
+    public function getReferences(): array
+    {
+        return $this->references;
+    }
+
+    /**
+     * Get the total amount of recursive references present in this lookup's record.
+     *
+     * @return int
+     */
+    public function getLookupCount(): int
+    {
+        return array_reduce($this->references, function ($total, $reference) {
+            return $total + $reference->getLookupCount();
+        }, 1);
+    }
+}

--- a/src/OnlineDnsLookup.php
+++ b/src/OnlineDnsLookup.php
@@ -20,7 +20,7 @@ class OnlineDnsLookup
     private $record;
 
     /**
-     * @var array<self>
+     * @var \SPFLib\OnlineDnsLookup[]
      */
     private $references = [];
 
@@ -43,27 +43,27 @@ class OnlineDnsLookup
     /**
      * Add a recursive reference that is included within this lookup's record.
      *
-     * @param self $reference
+     * @return $this
      */
-    public function addReference(self $reference): void
+    public function addReference(self $reference): self
     {
         $this->references[] = $reference;
+
+        return $this;
     }
 
     /**
      * Get all recursive references that are included in this lookup's record.
      *
-     * @return array<self>
+     * @return \SPFLib\OnlineDnsLookup[]
      */
     public function getReferences(): array
     {
-        return $this->references;
+        return $this->references[0];
     }
 
     /**
      * Get the total amount of recursive references present in this lookup's record.
-     *
-     * @return int
      */
     public function getLookupCount(): int
     {

--- a/src/OnlineDnsLookup.php
+++ b/src/OnlineDnsLookup.php
@@ -9,11 +9,20 @@ namespace SPFLib;
  */
 class OnlineDnsLookup
 {
-    private string $name;
+    /**
+     * @var string
+     */
+    private $name;
 
-    private ?string $record;
+    /**
+     * @var string|null
+     */
+    private $record;
 
-    private array $references = [];
+    /**
+     * @var array<self>
+     */
+    private $references = [];
 
     public function __construct(string $name, ?string $record = null)
     {
@@ -34,7 +43,7 @@ class OnlineDnsLookup
     /**
      * Add a recursive reference that is included within this lookup's record.
      *
-     * @param OnlineDnsLookup $reference
+     * @param self $reference
      */
     public function addReference(self $reference): void
     {

--- a/src/OnlineDnsLookup.php
+++ b/src/OnlineDnsLookup.php
@@ -35,7 +35,7 @@ class OnlineDnsLookup
         return $this->name;
     }
 
-    public function getRecord(): string
+    public function getRecord(): ?string
     {
         return $this->record;
     }

--- a/src/OnlineDnsLookup.php
+++ b/src/OnlineDnsLookup.php
@@ -10,7 +10,9 @@ namespace SPFLib;
 class OnlineDnsLookup
 {
     private string $name;
+
     private ?string $record;
+
     private array $references = [];
 
     public function __construct(string $name, ?string $record = null)
@@ -34,7 +36,7 @@ class OnlineDnsLookup
      *
      * @param OnlineDnsLookup $reference
      */
-    public function addReference(OnlineDnsLookup $reference): void
+    public function addReference(self $reference): void
     {
         $this->references[] = $reference;
     }

--- a/src/OnlineDnsLookup.php
+++ b/src/OnlineDnsLookup.php
@@ -67,7 +67,7 @@ class OnlineDnsLookup
      */
     public function getLookupCount(): int
     {
-        return array_reduce($this->references, function ($total, $reference) {
+        return array_reduce($this->references, static function ($total, $reference) {
             return $total + $reference->getLookupCount();
         }, 1);
     }

--- a/src/OnlineSemanticValidator.php
+++ b/src/OnlineSemanticValidator.php
@@ -116,6 +116,7 @@ class OnlineSemanticValidator
         if ($record) {
             return $this->getLookupsForRecord($record, $domain);
         }
+
         return [];
     }
 
@@ -133,9 +134,9 @@ class OnlineSemanticValidator
         $this->validateRecursive($domain, $record, $state);
         if (isset($state['subRecordsDNSLookups'])) {
             return $state['subRecordsDNSLookups'];
-        } else {
-            return [];
         }
+
+        return [];
     }
 
     protected function validate(string $domain, ?Record $record): array

--- a/src/OnlineSemanticValidator.php
+++ b/src/OnlineSemanticValidator.php
@@ -6,7 +6,7 @@ namespace SPFLib;
 
 use SPFLib\Check\State;
 use SPFLib\Semantic\OnlineIssue;
-use SPFLib\Semantic\OnlineIssueTooManyDNSLookups;
+use SPFLib\Semantic\OnlineIssue\TooManyDNSLookups;
 use SPFLib\Term\Mechanism;
 use SPFLib\Term\Modifier;
 
@@ -241,7 +241,7 @@ class OnlineSemanticValidator
             $totalDNSLookupCount = $state['subRecordsDNSLookupCount'];
             $maxQueries = State::MAX_DNS_LOOKUPS;
             if ($totalDNSLookupCount > $maxQueries) {
-                $result[] = new OnlineIssueTooManyDNSLookups(
+                $result[] = new TooManyDNSLookups(
                     $state['subRecordsDNSLookups'],
                     $domain,
                     '',

--- a/src/OnlineSemanticValidator.php
+++ b/src/OnlineSemanticValidator.php
@@ -91,7 +91,7 @@ class OnlineSemanticValidator
      *
      * @param string $domain the domain to be checked
      *
-     * @return array<OnlineDnsLookup>
+     * @return \SPFLib\OnlineDnsLookup[]
      */
     public function getLookupsForDomain(string $domain): array
     {
@@ -104,7 +104,7 @@ class OnlineSemanticValidator
      * @param string $txtRecord the raw SPF record to be checked
      * @param string $domain the domain owning the $txtRecord SFP record
      *
-     * @return array<OnlineDnsLookup>
+     * @return \SPFLib\OnlineDnsLookup[]
      */
     public function getLookupsForRawRecord(string $txtRecord, string $domain = ''): array
     {
@@ -126,7 +126,7 @@ class OnlineSemanticValidator
      * @param \SPFLib\Record|null $record the record to be checked
      * @param string $domain the domain owning the $record SFP record
      *
-     * @return array<OnlineDnsLookup>
+     * @return \SPFLib\OnlineDnsLookup[]
      */
     public function getLookupsForRecord(?Record $record, string $domain = ''): array
     {

--- a/src/Semantic/OnlineIssue/TooManyDNSLookups.php
+++ b/src/Semantic/OnlineIssue/TooManyDNSLookups.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace SPFLib\Semantic;
+namespace SPFLib\Semantic\OnlineIssue;
 
 use SPFLib\OnlineDnsLookup;
 use SPFLib\Record;
+use SPFLib\Semantic\OnlineIssue;
 
-class OnlineIssueTooManyDNSLookups extends OnlineIssue
+class TooManyDNSLookups extends OnlineIssue
 {
     /**
      * @var array<OnlineDnsLookup>

--- a/src/Semantic/OnlineIssue/TooManyDNSLookups.php
+++ b/src/Semantic/OnlineIssue/TooManyDNSLookups.php
@@ -4,21 +4,20 @@ declare(strict_types=1);
 
 namespace SPFLib\Semantic\OnlineIssue;
 
-use SPFLib\OnlineDnsLookup;
 use SPFLib\Record;
 use SPFLib\Semantic\OnlineIssue;
 
 class TooManyDNSLookups extends OnlineIssue
 {
     /**
-     * @var array<OnlineDnsLookup>
+     * @var \SPFLib\OnlineDnsLookup[]
      */
     private $dnsLookups;
 
     /**
      * Initialize the instance.
      *
-     * @param string $dnsLookups the direct DNS lookups that are present in this record
+     * @param \SPFLib\OnlineDnsLookup[] $dnsLookups the direct DNS lookups that are present in this record
      */
     public function __construct(
         array $dnsLookups,
@@ -36,7 +35,7 @@ class TooManyDNSLookups extends OnlineIssue
     /**
      * Get all direct DNS lookups that are present in this record.
      *
-     * @return array<OnlineDnsLookup>
+     * @return \SPFLib\OnlineDnsLookup[]
      */
     public function getDnsLookups(): array
     {

--- a/src/Semantic/OnlineIssue/TooManyDNSLookups.php
+++ b/src/Semantic/OnlineIssue/TooManyDNSLookups.php
@@ -50,7 +50,7 @@ class TooManyDNSLookups extends OnlineIssue
      */
     public function getTotalLookupCount(): int
     {
-        return array_reduce($this->dnsLookups, function ($total, $dnsLookup) {
+        return array_reduce($this->dnsLookups, static function ($total, $dnsLookup) {
             return $total + $dnsLookup->getLookupCount();
         }, 0);
     }

--- a/src/Semantic/OnlineIssueTooManyDNSLookups.php
+++ b/src/Semantic/OnlineIssueTooManyDNSLookups.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPFLib\Semantic;
+
+use SPFLib\OnlineDnsLookup;
+use SPFLib\Record;
+
+class OnlineIssueTooManyDNSLookups extends OnlineIssue
+{
+    /**
+     * @var array<OnlineDnsLookup>
+     */
+    private array $dnsLookups;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param string $dnsLookups the direct DNS lookups that are present in this record
+     */
+    public function __construct(
+        array $dnsLookups,
+        string $domain,
+        string $txtRecord,
+        ?Record $record,
+        int $code,
+        string $description,
+        int $level
+    ) {
+        parent::__construct($domain, $txtRecord, $record, $code, $description, $level);
+        $this->dnsLookups = $dnsLookups;
+    }
+
+    /**
+     * Get all direct DNS lookups that are present in this record.
+     *
+     * @return array<OnlineDnsLookup>
+     */
+    public function getDnsLookups(): array
+    {
+        return $this->dnsLookups;
+    }
+
+    /**
+     * Get the total amount of DNS lookups that are involved in this record.
+     *
+     * @return int
+     */
+    public function getTotalLookupCount(): int
+    {
+        return array_reduce($this->dnsLookups, function ($total, $dnsLookup) {
+            return $total + $dnsLookup->getTotalLookupCount();
+        }, 0);
+    }
+}

--- a/src/Semantic/OnlineIssueTooManyDNSLookups.php
+++ b/src/Semantic/OnlineIssueTooManyDNSLookups.php
@@ -12,7 +12,7 @@ class OnlineIssueTooManyDNSLookups extends OnlineIssue
     /**
      * @var array<OnlineDnsLookup>
      */
-    private array $dnsLookups;
+    private $dnsLookups;
 
     /**
      * Initialize the instance.

--- a/src/Semantic/OnlineIssueTooManyDNSLookups.php
+++ b/src/Semantic/OnlineIssueTooManyDNSLookups.php
@@ -50,7 +50,7 @@ class OnlineIssueTooManyDNSLookups extends OnlineIssue
     public function getTotalLookupCount(): int
     {
         return array_reduce($this->dnsLookups, function ($total, $dnsLookup) {
-            return $total + $dnsLookup->getTotalLookupCount();
+            return $total + $dnsLookup->getLookupCount();
         }, 0);
     }
 }

--- a/test/tests/OnlineSemanticValidatorTest.php
+++ b/test/tests/OnlineSemanticValidatorTest.php
@@ -249,11 +249,11 @@ class OnlineSemanticValidatorTest extends TestCase
         return [
             [
                 '',
-                0
+                0,
             ],
             [
                 'test.example.org',
-                0
+                0,
             ],
             [
                 'test.example.org',

--- a/test/tests/OnlineSemanticValidatorTest.php
+++ b/test/tests/OnlineSemanticValidatorTest.php
@@ -317,7 +317,7 @@ class OnlineSemanticValidatorTest extends TestCase
     {
         self::$resolver->setFakeTXTRecords($txtRecords);
         $lookups = self::$validator->getLookupsForDomain($domain);
-        $this->assertSame($expectedLookups, array_reduce($lookups, function ($total, $lookup) {
+        $this->assertSame($expectedLookups, array_reduce($lookups, static function ($total, $lookup) {
             return $total + $lookup->getLookupCount();
         }, 0));
     }
@@ -360,7 +360,7 @@ class OnlineSemanticValidatorTest extends TestCase
     {
         self::$resolver->setFakeTXTRecords($txtRecords);
         $lookups = self::$validator->getLookupsForRawRecord($rawRecord, $domain);
-        $this->assertSame($expectedLookups, array_reduce($lookups, function ($total, $lookup) {
+        $this->assertSame($expectedLookups, array_reduce($lookups, static function ($total, $lookup) {
             return $total + $lookup->getLookupCount();
         }, 0));
     }

--- a/test/tests/OnlineSemanticValidatorTest.php
+++ b/test/tests/OnlineSemanticValidatorTest.php
@@ -244,6 +244,127 @@ class OnlineSemanticValidatorTest extends TestCase
         $this->checkIssues($issues, $expectedIssueCodes, $minimumLevel);
     }
 
+    public function feedGetLookupsForDomainCases(): array
+    {
+        return [
+            [
+                '',
+                0
+            ],
+            [
+                'test.example.org',
+                0
+            ],
+            [
+                'test.example.org',
+                0,
+                ['test.example.org' => ['v=spf1 mal formed!']],
+            ],
+            [
+                'test1.example.org',
+                4,
+                [
+                    'test1.example.org' => ['v=spf1 include:test2.example.org include:test3.example.org -all'],
+                    'test2.example.org' => ['v=spf1 include:test4.example.org -all'],
+                    'test3.example.org' => ['v=spf1 include:test4.example.org -all'],
+                    'test4.example.org' => ['v=spf1 -all'],
+                ],
+            ],
+            [
+                'test.example.org',
+                0,
+                ['test.example.org' => ['v=spf1 include:_spf.%{d2} -all']],
+            ],
+            [
+                'test1.example.org',
+                11,
+                [
+                    'test1.example.org' => ['v=spf1 mx a include:test2.example.org include:test6.example.org include:test7.example.org ip4:1.2.3.4 ~all'],
+                    'test2.example.org' => ['v=spf1 ip4:1.2.3.4 include:test3.example.org ~all'],
+                    'test3.example.org' => ['v=spf1 ip4:1.2.3.4 include:test4.example.org ~all'],
+                    'test4.example.org' => ['v=spf1 ip4:1.2.3.4 include:test5.example.org ~all'],
+                    'test5.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test6.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test7.example.org' => ['v=spf1 include:test8.example.org include:test9.example.org include:test10.example.org ~all'],
+                    'test8.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test9.example.org' => ['v=spf1 ~all'],
+                    'test10.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                ],
+            ],
+            [
+                'test1.example.org',
+                10,
+                [
+                    'test1.example.org' => ['v=spf1 a include:test2.example.org include:test6.example.org include:test7.example.org ip4:1.2.3.4 ~all'],
+                    'test2.example.org' => ['v=spf1 ip4:1.2.3.4 include:test3.example.org ~all'],
+                    'test3.example.org' => ['v=spf1 ip4:1.2.3.4 include:test4.example.org ~all'],
+                    'test4.example.org' => ['v=spf1 ip4:1.2.3.4 include:test5.example.org ~all'],
+                    'test5.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test6.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test7.example.org' => ['v=spf1 include:test8.example.org include:test9.example.org include:test10.example.org ~all'],
+                    'test8.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test9.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                    'test10.example.org' => ['v=spf1 ip4:1.2.3.4 ~all'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider feedGetLookupsForDomainCases
+     */
+    public function testGetLookupsForDomain(string $domain, int $expectedLookups, array $txtRecords = []): void
+    {
+        self::$resolver->setFakeTXTRecords($txtRecords);
+        $lookups = self::$validator->getLookupsForDomain($domain);
+        $this->assertSame($expectedLookups, array_reduce($lookups, function ($total, $lookup) {
+            return $total + $lookup->getLookupCount();
+        }, 0));
+    }
+
+    public function feedGetLookupsForRawRecordCases(): array
+    {
+        return [
+            [
+                '', '',
+                0,
+            ],
+            [
+                'malformed', '',
+                0,
+            ],
+            [
+                'v=spf1 malformed', '',
+                0,
+            ],
+            [
+                'v=spf1 -all', '',
+                0,
+            ],
+            [
+                'v=spf1 include:test2.example.org include:test3.example.org -all', 'test1.example.org',
+                4,
+                [
+                    'test2.example.org' => ['v=spf1 include:test4.example.org -all'],
+                    'test3.example.org' => ['v=spf1 include:test4.example.org -all'],
+                    'test4.example.org' => ['v=spf1 -all'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider feedGetLookupsForRawRecordCases
+     */
+    public function testGetLookupsForRawRecord(string $rawRecord, string $domain, int $expectedLookups, array $txtRecords = []): void
+    {
+        self::$resolver->setFakeTXTRecords($txtRecords);
+        $lookups = self::$validator->getLookupsForRawRecord($rawRecord, $domain);
+        $this->assertSame($expectedLookups, array_reduce($lookups, function ($total, $lookup) {
+            return $total + $lookup->getLookupCount();
+        }, 0));
+    }
+
     private function checkIssues(array $issues, array $expectedIssueCodes, ?int $minimumLevel)
     {
         $this->assertSameSize($expectedIssueCodes, $issues);


### PR DESCRIPTION
I've expanded `OnlineSemanticValidator` to include more information about DNS lookups:

### For validation issues

When an issue of type `CODE_TOO_MANY_DNS_LOOKUPS_ONLINE` occurs, it is now returned as an instance of `OnlineIssueTooManyDNSLookups`, which includes additional methods for retrieving detailed information.

- `getTotalLookupCount()` returns the total amount of DNS lookups required for the SPF record.
- `getDnsLookups()` returns a recursive list of all DNS lookups required for the SPF record. This is an array of `OnlineDnsLookup` instances, which themselves provide the methods `getName()`, `getRecord()`, `getReferences()` and `getLookupCount()` for retrieving detailed information.

### Checking lookups without validation

Sometimes you might want to investigate a record's DNS lookups, even if the SPF record is valid. For this I've added the methods `getLookupsForDomain(string $domain)`, `getLookupsForRawRecord(string $txtRecord, string $domain = '')` and `getLookupsForRecord(?Record $record, string $domain = '')`, which return an array of `OnlineDnsLookup` instances.