### PR TITLE
Add Decoder::getTXTRecordFromDomain()

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -45,11 +45,11 @@ class Decoder
      * @throws \SPFLib\Exception\DNSResolutionException in case of DNS resolution errors
      * @throws \SPFLib\Exception\MultipleSPFRecordsException if the domain has more that 1 SPF record
      *
-     * @return string|null return NULL if no SPF TXT record has been found
+     * @return string returns an empty string if no SPF TXT record has been found
      *
      * @see https://tools.ietf.org/html/rfc7208#section-4.5
      */
-    public function getTXTRecordFromDomain(string $domain): ?string
+    public function getTXTRecordFromDomain(string $domain): string
     {
         $rawSpfRecords = [];
         $txtRecords = $this->getDNSResolver()->getTXTRecords($domain);
@@ -60,7 +60,7 @@ class Decoder
         }
         switch (count($rawSpfRecords)) {
             case 0:
-                return null;
+                return '';
             case 1:
                 return $rawSpfRecords[0];
             default:
@@ -83,7 +83,7 @@ class Decoder
     public function getRecordFromDomain(string $domain): ?Record
     {
         $txtRecord = $this->getTXTRecordFromDomain($domain);
-        if ($txtRecord === null) {
+        if ($txtRecord === '') {
             return null;
         }
 

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -86,6 +86,7 @@ class Decoder
         if ($txtRecord === null) {
             return null;
         }
+
         return $this->getRecordFromTXT($txtRecord);
     }
 

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -40,6 +40,35 @@ class Decoder
     }
 
     /**
+     * Get the raw SPF TXT record associated to a domain.
+     *
+     * @throws \SPFLib\Exception\DNSResolutionException in case of DNS resolution errors
+     * @throws \SPFLib\Exception\MultipleSPFRecordsException if the domain has more that 1 SPF record
+     *
+     * @return string|null return NULL if no SPF TXT record has been found
+     *
+     * @see https://tools.ietf.org/html/rfc7208#section-4.5
+     */
+    public function getTXTRecordFromDomain(string $domain): ?string
+    {
+        $rawSpfRecords = [];
+        $txtRecords = $this->getDNSResolver()->getTXTRecords($domain);
+        foreach ($txtRecords as $txtRecord) {
+            if (strcasecmp($txtRecord, Record::PREFIX) === 0 || stripos($txtRecord, Record::PREFIX . ' ') === 0) {
+                $rawSpfRecords[] = $txtRecord;
+            }
+        }
+        switch (count($rawSpfRecords)) {
+            case 0:
+                return null;
+            case 1:
+                return $rawSpfRecords[0];
+            default:
+                throw new Exception\MultipleSPFRecordsException($domain, $rawSpfRecords);
+        }
+    }
+
+    /**
      * Extract the SPF record associated to a domain.
      *
      * @throws \SPFLib\Exception\DNSResolutionException in case of DNS resolution errors
@@ -53,21 +82,11 @@ class Decoder
      */
     public function getRecordFromDomain(string $domain): ?Record
     {
-        $rawSpfRecords = [];
-        $txtRecords = $this->getDNSResolver()->getTXTRecords($domain);
-        foreach ($txtRecords as $txtRecord) {
-            if (strcasecmp($txtRecord, Record::PREFIX) === 0 || stripos($txtRecord, Record::PREFIX . ' ') === 0) {
-                $rawSpfRecords[] = $txtRecord;
-            }
+        $txtRecord = $this->getTXTRecordFromDomain($domain);
+        if ($txtRecord === null) {
+            return null;
         }
-        switch (count($rawSpfRecords)) {
-            case 0:
-                return null;
-            case 1:
-                return $this->getRecordFromTXT($rawSpfRecords[0]);
-            default:
-                throw new Exception\MultipleSPFRecordsException($domain, $rawSpfRecords);
-        }
+        return $this->getRecordFromTXT($txtRecord);
     }
 
     /**


### PR DESCRIPTION
This PR moves SPF TXT record finding functionality to its function, `getTXTRecordFromDomain`.

For my project, I would like to have access to the raw DNS text record to show to users whenever possible. Currently, this is not possible since TXT record finding happens within `getRecordFromDomain`, so it's impossible to access the raw TXT record outside of that function. 

With the PR, the following is possible:
```php
$decoder = new \SPFLib\Decoder();
$rawRecord = null;

try {
	$rawRecord = $decoder->getTXTRecordFromDomain("example.com");
} catch ( \Exception $e ) {
	// Handle raw TXT record-related error.
}

$record = null;

if ($rawRecord) {
	try {
		$record = $decoder->getRecordFromTXT($rawRecord);
	} catch ( \Exception $e ) {
		// Handle recording parsing-related error.
		// Has access to $rawRecord to provide further context.
	}
}

// Has access to both $rawRecord and $record.